### PR TITLE
Removed logging for libdap and hyrax-dependencies

### DIFF
--- a/better_hyrax_build.sh
+++ b/better_hyrax_build.sh
@@ -25,22 +25,27 @@ source spath.sh
 echo $prefix
 
 # Build Hyrax dependencies
-rm hyrax-dependencies_make.log
+#rm hyrax-dependencies_make.log
 cd hyrax-dependencies
-make 2>&1 | tee ../hyrax-dependencies_make.log
+make
+#make 2>&1 | tee ../hyrax-dependencies_make.log
 cd ..
 
 # Reconfigure and rebuild libdap4
-rm libdap4_config.log
-rm libdap4_make.log
-rm libdap4_make_check.log
-rm libdap4_make_install.log
+#rm libdap4_config.log
+#rm libdap4_make.log
+#rm libdap4_make_check.log
+#rm libdap4_make_install.log
 cd libdap4
 autoreconf -vif
-./configure --prefix=$prefix --enable-developer 2>&1 | tee ../libdap4_config.log
-make 2>&1 | tee ../libdap4_make.log
-make check 2>&1 | tee ../libdap4_make_check.log
-make install 2>&1 | tee ../libdap4_make_install.log
+./configure --prefix=$prefix --enable-developer
+make
+make check
+make install
+#./configure --prefix=$prefix --enable-developer 2>&1 | tee ../libdap4_config.log
+#make 2>&1 | tee ../libdap4_make.log
+#make check 2>&1 | tee ../libdap4_make_check.log
+#make install 2>&1 | tee ../libdap4_make_install.log
 cd ..
 
 # Reconfigure and rebuild bes


### PR DESCRIPTION
Removed (commented out) build logging for libdap and hyrax-dependencies as it seemed to be slowing down the build.